### PR TITLE
Adding simple watchable functional test capabilities

### DIFF
--- a/generators/app/gulpfile.js
+++ b/generators/app/gulpfile.js
@@ -93,3 +93,21 @@ function build() {
 }
 
 gulp.task('build', build);
+
+// Polymer 1 element function testing
+const mocha = require('gulp-mocha');
+
+function functest() {
+  return new Promise((resolve, reject) => {
+    let teststream = gulp.src(['functest/*.js'], { read: false })
+    .pipe(mocha({ reporter: 'list' }))
+    .on('end', resolve)
+    .on('error', resolve); // we don't want to jump out of 'watch'
+  });
+}
+
+gulp.task('functest', functest);
+
+gulp.task('watch', () => {
+  gulp.watch(['src/**/*.html', 'functest/*.js'], functest);
+});

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -40,6 +40,17 @@ module.exports = yeoman.Base.extend({
       this.destinationPath('gulpfile.js')
     );
 
+    // Copy function test example files
+    this.fs.copy(
+      this.templatePath('my-view1.js'),
+      this.destinationPath('functest/my-view1.js')
+    );
+
+    this.fs.copy(
+      this.templatePath('my-view1.html'),
+      this.destinationPath('src/my-view1.js')
+    );
+
     // Overwrite the PSK files with new files
     this.fs.copy(
       this.templatePath('{package.json,README.md}'),

--- a/generators/app/my-view1.html
+++ b/generators/app/my-view1.html
@@ -1,0 +1,47 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="shared-styles.html">
+
+<dom-module id="my-view1">
+  <template>
+    <style include="shared-styles">
+      :host {
+        display: block;
+
+        padding: 10px;
+      }
+    </style>
+
+    <div class="card">
+      <div class="circle">1</div>
+      <h1>View One</h1>
+      <p>Ut labores minimum atomorum pro. Laudem tibique ut has.</p>
+      <p>Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea.Lorem ipsum dolor sit amet, per in nusquam nominavi periculis, sit elit oportere ea.Cu mei vide viris gloriatur, at populo eripuit sit.</p>
+      <br>
+      <br>
+      Adding 1 and 2 gives [[add(1,2)]]
+    </div>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'my-view1',
+
+      /**
+       * Dummy function for functional testing
+       */
+      add:function(a,b) {
+        return a + b;
+      }
+    });
+  </script>
+</dom-module>

--- a/generators/app/my-view1.js
+++ b/generators/app/my-view1.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const gulp = require('gulp');
+const polymerBuild = require('polymer-build');
+const polymerJson = require('../polymer.json');
+const polymerProject = new polymerBuild.PolymerProject(polymerJson);
+const filter = require('gulp-filter');
+const intercept = require('gulp-intercept');
+
+const jsFilter = filter('**/*.js');
+
+const assert = require('assert');
+const expect = require('expect');
+
+describe('Testing functions in <my-view1>', () => {
+  let polyobj;
+
+  before(done => {
+    let Polymer = data => polyobj = data;
+
+    gulp.src('./src/my-view1.html')
+      .pipe(polymerProject.splitHtml())
+      .pipe(jsFilter)
+      .pipe(intercept(file => eval(file.contents.toString())) )
+      .on('end', done);
+  });
+
+  it('Add function exists', () => {
+    assert(polyobj.add);
+  });
+  it('Add function adds correctly', () => {
+    expect(polyobj.add(1,2)).toBe(3);
+  });
+});

--- a/generators/app/package.json
+++ b/generators/app/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "lint": "eslint . --ext js,html --ignore-path .gitignore",
     "test": "npm run lint && polymer test",
-    "build": "gulp build"
+    "functest": "gulp functest",
+    "build": "gulp build",
+    "watch": "gulp watch"
   },
   "devDependencies": {
     "del": "^2.2.0",
@@ -16,6 +18,10 @@
     "gulp": "gulpjs/gulp#4.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^3.1.0",
+    "expect": "^1.20.2",
+    "gulp-filter": "^5.0.0",
+    "gulp-intercept": "^0.1.0",
+    "gulp-mocha": "^3.0.1",
     "merge-stream": "^1.0.0",
     "polymer-build": "^0.6.0"
   },


### PR DESCRIPTION
Hi @robdodson ,

The Good:

This small addition allows creation of unit/functional test files (residing in 'functest', which are picked up on any element code change  (html under src) or functional test script change (js under functest).

The Bad:
 
I have tried it locally in the generated project, where it works fine, but couldn't see how to run and test the modified generator with a local setup (only when pulled from npm... more to learn).  So what you see is modified to match the working project but not actally tried out as is (so I fully accept some iterations here).

The Ugly:

Currently, each test script finds a specific Polymer 1 element file and uses the existing build functionality to rip out and eval the script part, where the Polymer function is hijacked (works for locally mocked function testing - but maybe you have a better idea?).

Anyway - please tell me where to go from here :)

NOTE:  In our devgroup, we need something for Polymer 2 like this VERY soon - and given the approach would not work on classes (the same way as hijacking the Polymer function), I'd really appreciate some inspirational input ;) 

br
Lars
