### PR TITLE
Generate the HTTP/2 Push Manifest

### DIFF
--- a/generators/app/gulpfile.js
+++ b/generators/app/gulpfile.js
@@ -98,7 +98,7 @@ function build() {
         // load them.
         buildStream = buildStream.pipe(polymerProject.bundler());
 
-        // Okay, now let's generate the HTTP/2 Push Manifest
+        // Now let's generate the HTTP/2 Push Manifest
         buildStream = buildStream.pipe(polymerProject.addPushManifest());
 
         // Okay, time to pipe to the build directory

--- a/generators/app/gulpfile.js
+++ b/generators/app/gulpfile.js
@@ -98,6 +98,9 @@ function build() {
         // load them.
         buildStream = buildStream.pipe(polymerProject.bundler());
 
+        // Okay, now let's generate the HTTP/2 Push Manifest
+        buildStream = buildStream.pipe(polymerProject.addPushManifest());
+
         // Okay, time to pipe to the build directory
         buildStream = buildStream.pipe(gulp.dest(buildDirectory));
 


### PR DESCRIPTION
It is the right way?
We should remove the bundling?

BTW, before I have seen the documentation, I expect something like:

```javascript
.then(() => {
  // Okay, now let's generate the HTTP/2 Push Manifest
  console.log('Generating the Service Worker...');
  return polymerBuild.addPushManifest();
})
```